### PR TITLE
Force global/by accept queue secure requests only with httpsonly flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Usage: http-later [[-v|--verbose], ...] [-q|--quiet|-s|--silent]
   -S  --storage=<sspec> configure server storage; see Storage below
   -T  --tls=<certspec>  enable TLS server and set default server cert
                         q.v., Accepting Request tls option for more info
+  -F  --httpsonly       fore https security on incoming insecure requests for all accept queues
   -v  --verbose         increase output; use multiple times for more output
 
 Accepting Requests
@@ -30,6 +31,7 @@ Accepting Requests
   port      port on which server should listen
   tls       paths to TLS certs (requires -T options); expects colon-delimited
             file paths: [<pfx>|<cert>:<key>[[:<ca>], ...]]
+  httpsonly fore https security on incoming insecure requests (flag)
   
   Example: http-later --accept=host:example.com,methods:GET:POST,port:8080
   

--- a/lib/accept-rule.js
+++ b/lib/accept-rule.js
@@ -14,6 +14,7 @@ var prop = require("propertize");
  * @param {string|Buffer} [opts.tls.cert]       public certificate
  * @param {string|Buffer} [opts.tls.key]        certificate private key
  * @param {array|string|Buffer} [opts.tls.ca]   intermediate certs
+ * @param {boolean} [opts.httpsonly]            ugrade insecure request to secure ones
  */
 function AcceptRule(opts) {
     var rule = this;
@@ -24,6 +25,7 @@ function AcceptRule(opts) {
     this.port = Number(opts.port) > 0 ? Number(opts.port) : 0;
     this.forward = opts.forward ? String(opts.forward) : undefined;
     this.tls = opts.tls || false;
+    this.httpsonly = !!opts.httpsonly;
 
     if (!this.port) this.port = this.tls ? 443 : 80;
 
@@ -103,6 +105,7 @@ AcceptRule.readTLSOption = function(tls) {
  * @param {string} [rule.path]
  * @param {string[]} [rule.paths]
  * @param {object} [rule.tls]
+ * @param {boolean} [rule.httpsonly]
  * @returns {AcceptRule[]}
  */
 AcceptRule.readAcceptRule = function(rule) {
@@ -112,6 +115,7 @@ AcceptRule.readAcceptRule = function(rule) {
         methods = rule.methods instanceof Array ? rule.methods.slice() : [],
         tls = AcceptRule.readTLSOption(rule.tls),
         port = parseInt(rule.port);
+        httpsonly = rule.httpsonly;
 
     if (!(port > 0)) port = tls ? 443 : 80;
     if (typeof rule.path === "string") paths.push(rule.path);
@@ -129,6 +133,7 @@ AcceptRule.readAcceptRule = function(rule) {
             opts.method = method;
             opts.tls = tls;
             opts.port = port;
+            opts.httpsonly = !!httpsonly;
 
             results.push(new AcceptRule(opts));
         });
@@ -143,7 +148,7 @@ AcceptRule.readAcceptRule = function(rule) {
  */
 AcceptRule.prototype.toString = function() {
     var stdPort = this.tls ? 443 : 80,
-        scheme = this.tls ? "https" : "http",
+        scheme = this.tls || this.httpsonly ? "https" : "http",
         host = this.host || "<any>",        
         port = this.port === stdPort ? "" : ":" + this.port,
         path = this.path || "/",

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -68,7 +68,7 @@ function later(later) {
                     res.writeHead(500, {"Content-Type": "text/plain"});
                     res.end(err.message);
                 } else {
-                    res.writeHead(202, {"X-Later-Key": key});
+                    res.writeHead(202, {"X-Later-Key": key,"X-Later-Scheme": rule.tls || rule.httpsonly ? "https" : "http"});
                     res.end();
 
                     concussion.write(req.headers, "X-Later-Key", key);

--- a/lib/serialize-incoming.js
+++ b/lib/serialize-incoming.js
@@ -25,8 +25,8 @@ function serializeIncoming(req, done) {
 
         // check if replay should force TLS/no-TLS
         if (name.toLowerCase() === "x-later-tls") {
-            if (!tls && req.headers[name] === "insecure") tls = false;
-            else if (req.headers[name] === "secure") tls = true;
+            if (!tls && !httpsonly && req.headers[name] === "insecure") tls = false;
+            else if (req.headers[name] === "secure" || httpsonly) tls = true;
 
             // skip this header; normalized value written below
             continue;
@@ -37,7 +37,7 @@ function serializeIncoming(req, done) {
     }
 
     // always add X-Later-TLS header
-    if (tls === undefined) tls = !!req.socket.encrypted;
+    if (tls === undefined) tls = !!req.socket.encrypted || httpsonly;
     serialized.headers["X-Later-TLS"] = tls ? "secure" : "insecure";
 
     // serialize body


### PR DESCRIPTION
The changes might be improvable because I have nearly no nodejs
experience but behavior is as expected and working ... ;)